### PR TITLE
Update config to point to TribeHR sandbox env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The file "config.php" is found right in the root directory. Here you'll set up e
  Given to you by TribeHR along with your Integration ID. Enter it as a string.
 
  - ###### TRIBEHR_LOOKUP_API_ENDPOINT
- The base URL used for Lookup API calls. By default, this points to TribeHR's production environment. For testing, you might want to create a simple web app to accept your queries so that you can look at what the sample app is sending out, or control the different possible requests and responses that TribeHR can generate. If you do, you can change the endpoint here to map to your mock system instead.
+ The base URL used for Lookup API calls. By default, this points to TribeHR's sandbox development environment. Once your panel has been approved, you should use the commented-out production endpoint. For testing, you might want to create a simple web app to accept your queries so that you can look at what the sample app is sending out, or control the different possible requests and responses that TribeHR can generate. If you do, you can change the endpoint here to map to your mock system instead.
 
  - ###### REQUEST_LOGGING_ENABLED
  If you set this to _true_ instead of the default _false_, the sample app will begin verbosely logging debug information to the file *logs/request.log*. This will help you follow along with each step, but will pile up very quickly.

--- a/config.php
+++ b/config.php
@@ -6,8 +6,12 @@ date_default_timezone_set('UTC');
 define('INTEGRATION_ID', '[put your integration ID here]');
 define('SECRET_SHARED_KEY', '[put your secret shared key here]');
 
-// Endpoint URL. Re-point locally for testing if desired.
-define('TRIBEHR_LOOKUP_API_ENDPOINT', 'https://app.tribehr.com/lookup/');
+// Lookup API endpoint to connect to.
+// Ensure that you're pointing to either the production or sandbox environment as appropriate and matches your
+//  integration ID and shared key.
+// You can also mock out the TribeHR system and point to your own solution for testing
+define('TRIBEHR_LOOKUP_API_ENDPOINT', 'https://app.sandbox.tribehr.com/lookup/');		// development sandbox
+// define('TRIBEHR_LOOKUP_API_ENDPOINT', 'https://app.tribehr.com/lookup/');			// production environment
 
 // Values that can be useful for debugging/testing an integration
 define('REQUEST_LOGGING_ENABLED', false);


### PR DESCRIPTION
1. Update config.php to point new partners to the sandbox API URL, instead of the prod. one, with the prod one present and an explanation so that they get the concept of two environments and that they're in charge of pointing their panel as appropriate
2. Update the readme to be accurate with the new config file

Basically, the review is just "do these changes read well, and are they technically accurate".
## Testing Notes
- you can visually see the updated readme here: https://github.com/iniq/Panels-Example/tree/sandbox_config
- code won't actually run without properly setting up your config anyway, so up to you if you want to run it just to see if I actually typed the sandbox URL correctly or not. That's the only change point.
